### PR TITLE
Additional multicodec support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
 			"name": "multiformat-inspector",
 			"version": "0.0.1",
 			"dependencies": {
-				"multiformats": "^13.2.2",
-				"multihashes": "^4.0.3"
+				"multiformats": "^13.2.2"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.0.0",
@@ -587,11 +586,6 @@
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
-		},
-		"node_modules/@multiformats/base-x": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-			"integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -2391,42 +2385,10 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"node_modules/multibase": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-			"integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-			"deprecated": "This module has been superseded by the multiformats module",
-			"dependencies": {
-				"@multiformats/base-x": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=12.0.0",
-				"npm": ">=6.0.0"
-			}
-		},
 		"node_modules/multiformats": {
 			"version": "13.2.2",
 			"resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
 			"integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
-		},
-		"node_modules/multihashes": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-			"integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-			"dependencies": {
-				"multibase": "^4.0.1",
-				"uint8arrays": "^3.0.0",
-				"varint": "^5.0.2"
-			},
-			"engines": {
-				"node": ">=12.0.0",
-				"npm": ">=6.0.0"
-			}
-		},
-		"node_modules/multihashes/node_modules/varint": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-			"integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.7",
@@ -3316,19 +3278,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/uint8arrays": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-			"dependencies": {
-				"multiformats": "^9.4.2"
-			}
-		},
-		"node_modules/uint8arrays/node_modules/multiformats": {
-			"version": "9.9.0",
-			"resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-			"integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,86 +1,139 @@
 <script lang="ts">
-	import { bases } from 'multiformats/basics';
+	import { bases, varint } from 'multiformats/basics';
 	import { decode } from 'multiformats/hashes/digest';
 	import { toHex, fromHex } from 'multiformats/bytes';
 	import { multicodecs } from '$lib/index.js';
 
-	interface DecodedHash {
+	interface DecodedMultiformat {
 		multibase: string;
-		hashName: string;
-		hashCode: string;
-		digest: Uint8Array;
-		length: number;
+		multicodec: string;
+		multicodecName: string;
+		multicodecTag: string;
+		ipldCode?: string;
+		ipldName?: string;
+		hashCode?: string;
+		hashName?: string;
+		digest?: Uint8Array;
+		length?: number;
+		bytes?: Uint8Array;
 	}
 
-	let inputHash: string = '';
-	let decodedHash: DecodedHash | null = null;
+	let inputMultiformat: string = '';
+	let decodedMultiformat: DecodedMultiformat | null = null;
 	let error: string = '';
-	$: hasResult = decodedHash || error;
+	$: hasResult = decodedMultiformat || error;
 
 	// type MultibaseFormats = keyof typeof bases;
 
-	function getBase(hash: string): any | null {
-		const prefix = hash[0];
+	function getBase(multiformat: string): any | null {
+		const prefix = multiformat[0];
 		const pair = Object.entries(bases).find(([_k, base]) => base.prefix === prefix);
 		return pair ? pair[1] : null;
 	}
 
-	function decodeMultibase() {
-		decodedHash = null;
+	function decodeInput() {
+		decodedMultiformat = null;
 		error = '';
-		const encodedHash = inputHash.trim();
-		if (encodedHash === '') {
+		const encodedMultiformat = inputMultiformat.trim();
+		if (encodedMultiformat === '') {
 			return;
 		}
 		try {
 			error = '';
 			let baseName = 'None';
-			let multihashEncoded =
-				encodedHash.substring(0, 2) === '0x' ? fromHex(encodedHash.substring(2)) : null;
-			if (encodedHash.substring(0, 2) !== '0x') {
-				const base = getBase(encodedHash);
+			let multiformatEncoded =
+				encodedMultiformat.substring(0, 2) === '0x'
+					? fromHex(encodedMultiformat.substring(2))
+					: null;
+			if (encodedMultiformat.substring(0, 2) !== '0x') {
+				const base = getBase(encodedMultiformat);
 				if (!base) {
 					error = 'Unknown Encoding';
 					return;
 				}
-				multihashEncoded = base.decode(encodedHash) || null;
+				multiformatEncoded = base.decode(encodedMultiformat) || null;
 				baseName = base.name;
 			}
-			if (!multihashEncoded) {
+			if (!multiformatEncoded) {
 				throw new Error('Unable to decode');
 			}
-
-			const decodedMultihash = decode(multihashEncoded);
-			const multicode = `0x${decodedMultihash.code.toString(16)}`;
-			const multicodec = multicodecs.find((x) => x.code === multicode);
-			decodedHash = {
-				multibase: baseName,
-				hashName: multicodec ? multicodec.name : 'Unknown',
-				hashCode: `0x${decodedMultihash.code.toString()}`,
-				digest: decodedMultihash.digest,
-				length: decodedMultihash.digest.length
-			};
+			decodedMultiformat = decodeMultiformat(multiformatEncoded, baseName);
 		} catch (err: unknown) {
 			error = (err as Error).message || 'Unable to decode';
 		}
 	}
+
+	function decodeMultiformat(multiformatEncoded: Uint8Array, baseName: string) {
+		let decodedMultiformat: DecodedMultiformat | null = null;
+		const [code, sizeOffset] = varint.decode(multiformatEncoded);
+		const multicode = `0x${code.toString(16).padStart(2, '0')}`;
+		const multicodec = multicodecs.find((x) => x.code === multicode);
+		decodedMultiformat = {
+			multibase: baseName,
+			multicodecName: multicodec ? multicodec.name : 'Unknown',
+			multicodecCode: multicodec.code,
+			multicodecTag: multicodec.tag
+		};
+		switch (multicodec.tag) {
+			case 'multihash':
+				const decodedMultihash = decode(multiformatEncoded);
+				decodedMultiformat.digest = decodedMultihash.digest;
+				decodedMultiformat.length = decodedMultihash.digest.length;
+				break;
+			case 'cid':
+				if (multicodec.name === 'cidv1') {
+					const [ipldCode, ipldOffset] = varint.decode(multiformatEncoded.subarray(sizeOffset));
+					const ipldHexCode = `0x${ipldCode.toString(16).padStart(2, '0')}`;
+					console.log({ ipldCode });
+					const ipldMulticodec = multicodecs.find((x) => x.code === ipldHexCode);
+					decodedMultiformat.ipldCode = ipldHexCode;
+					decodedMultiformat.ipldName = ipldMulticodec.name;
+
+					// Recursively handle the remaining multihash
+					const internalDecoded = decodeMultiformat(
+						multiformatEncoded.subarray(sizeOffset + ipldOffset),
+						baseName
+					);
+					decodedMultiformat.hashName = internalDecoded.multicodecName;
+					decodedMultiformat.hashCode = internalDecoded.multicodecCode;
+					decodedMultiformat.digest = internalDecoded.digest;
+					decodedMultiformat.length = internalDecoded.digest.length;
+					break;
+				}
+			default:
+				decodedMultiformat.bytes = multiformatEncoded.subarray(sizeOffset);
+		}
+		return decodedMultiformat;
+	}
 </script>
 
 <main>
-	<h1>Multiformat Multibase Multihash Inspector</h1>
+	<h1>Multiformat Multibase Inspector (Multihash and More)</h1>
 
-	<label for="input-hash">Enter a Multibase hash or a 0x prefixed hex Multihash:</label>
-	<input type="text" id="input-hash" bind:value={inputHash} />
-	<button on:click={decodeMultibase}>Decode</button>
+	<label for="input-hash">Enter a Multibase string or a 0x prefixed hex Multiformat value:</label>
+	<input type="text" id="input-multiformat" bind:value={inputMultiformat} />
+	<button on:click={decodeInput}>Decode</button>
 
 	{#if hasResult}
 		<div>
-			<h2>Decoded Multihash</h2>
-			{#if decodedHash}
-				<p>Multibase Encoding: {decodedHash.multibase}</p>
-				<p>Hash Algorithm: {decodedHash.hashName} ({decodedHash.hashCode})</p>
-				<p>Digest: {decodedHash ? '0x' + toHex(decodedHash.digest) : 'Unknown'}</p>
-				<p>Length: {decodedHash.length}</p>
+			<h2>Decoded Multiformat</h2>
+			{#if decodedMultiformat}
+				<p>Multibase Encoding: {decodedMultiformat.multibase}</p>
+				<p>
+					Multicodec Name: {decodedMultiformat.multicodecName} ({decodedMultiformat.multicodecCode})
+				</p>
+				<p>Multicodec Tag: {decodedMultiformat.multicodecTag}</p>
+				{#if decodedMultiformat.ipldCode}
+					<p>IPLD Codec: {decodedMultiformat.ipldName} ({decodedMultiformat.ipldCode})</p>
+					<p>CID Hash Algorithm: {decodedMultiformat.hashName} ({decodedMultiformat.hashCode})</p>
+				{/if}
+				{#if decodedMultiformat.digest}
+					<p>Digest: {decodedMultiformat ? '0x' + toHex(decodedMultiformat.digest) : 'Unknown'}</p>
+					<p>Length: {decodedMultiformat.length}</p>
+				{:else}
+					<p>Bytes: {'0x' + toHex(decodedMultiformat.bytes)}</p>
+					<p>Length: {decodedMultiformat.bytes.length}</p>
+				{/if}
 			{:else if error}
 				<p>Error: {error}</p>
 			{/if}


### PR DESCRIPTION
Added support for at least showing what multicodec was found for other types (e.g. tag="key").

If a cidv1 is detected, the IPLD codec and inner hash are parsed.